### PR TITLE
Include rules for `.tsx` files

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.ts'],
+      files: ['*.ts', '*.tsx'],
       parserOptions: {
         project: './tsconfig.json',
       },


### PR DESCRIPTION
The current rules just apply to `.ts` files and not to `.tsx` files that we use in our react projects.
Modifying the global eslint config seems to be the best way to enable linting for these files across all our react projects.

Related task from the Hub: https://github.com/jvalue/hub/issues/58