### PR TITLE
Update linting rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,6 @@ module.exports = {
       rules: {
         'prettier/prettier': 'warn',
 
-        '@typescript-eslint/array-type': [
-          'warn',
-          {
-            default: 'array-simple',
-            readonly: 'generic',
-          },
-        ],
         '@typescript-eslint/consistent-type-assertions': [
           'error',
           {
@@ -76,7 +69,6 @@ module.exports = {
 
         'accessor-pairs': 'error',
         'array-callback-return': 'error',
-        'capitalized-comments': ['warn', 'always'],
         curly: 'error',
         'default-case-last': 'error',
         'default-param-last': 'error',

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ module.exports = {
         '@typescript-eslint/prefer-includes': 'error',
         '@typescript-eslint/prefer-string-starts-ends-with': 'error',
         '@typescript-eslint/strict-boolean-expressions': 'error',
+        '@typescript-eslint/switch-exhaustiveness-check': 'warn',
 
         'accessor-pairs': 'error',
         'array-callback-return': 'error',

--- a/index.js
+++ b/index.js
@@ -88,10 +88,6 @@ module.exports = {
         ],
         'no-self-compare': 'error',
         'no-throw-literal': 'error',
-
-        // See https://github.com/typescript-eslint/typescript-eslint/issues/1041
-        'no-unreachable': 'error',
-
         'no-useless-rename': 'error',
         'no-useless-return': 'error',
         'import/first': 'warn',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jvalue/eslint-config-jvalue",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "license": "Apache-2.0",
   "keywords": [
     "eslint",

--- a/react.js
+++ b/react.js
@@ -32,13 +32,6 @@ module.exports = {
       rules: {
         'prettier/prettier': 'warn',
 
-        '@typescript-eslint/array-type': [
-          'warn',
-          {
-            default: 'array-simple',
-            readonly: 'generic',
-          },
-        ],
         '@typescript-eslint/consistent-type-assertions': [
           'error',
           {
@@ -74,10 +67,10 @@ module.exports = {
         '@typescript-eslint/prefer-includes': 'error',
         '@typescript-eslint/prefer-string-starts-ends-with': 'error',
         '@typescript-eslint/strict-boolean-expressions': 'error',
+        '@typescript-eslint/switch-exhaustiveness-check': 'warn',
 
         'accessor-pairs': 'error',
         'array-callback-return': 'error',
-        'capitalized-comments': ['warn', 'always'],
         curly: 'error',
         'default-case-last': 'error',
         'default-param-last': 'error',
@@ -97,10 +90,6 @@ module.exports = {
         ],
         'no-self-compare': 'error',
         'no-throw-literal': 'error',
-
-        // See https://github.com/typescript-eslint/typescript-eslint/issues/1041
-        'no-unreachable': 'error',
-
         'no-useless-rename': 'error',
         'no-useless-return': 'error',
         'import/first': 'warn',

--- a/vue.js
+++ b/vue.js
@@ -30,13 +30,6 @@ module.exports = {
       rules: {
         'prettier/prettier': 'warn',
 
-        '@typescript-eslint/array-type': [
-          'warn',
-          {
-            default: 'array-simple',
-            readonly: 'generic',
-          },
-        ],
         '@typescript-eslint/consistent-type-assertions': [
           'error',
           {
@@ -72,10 +65,10 @@ module.exports = {
         '@typescript-eslint/prefer-includes': 'error',
         '@typescript-eslint/prefer-string-starts-ends-with': 'error',
         '@typescript-eslint/strict-boolean-expressions': 'error',
+        '@typescript-eslint/switch-exhaustiveness-check': 'warn',
 
         'accessor-pairs': 'error',
         'array-callback-return': 'error',
-        'capitalized-comments': ['warn', 'always'],
         curly: 'error',
         'default-case-last': 'error',
         'default-param-last': 'error',
@@ -95,10 +88,6 @@ module.exports = {
         ],
         'no-self-compare': 'error',
         'no-throw-literal': 'error',
-
-        // See https://github.com/typescript-eslint/typescript-eslint/issues/1041
-        'no-unreachable': 'error',
-
         'no-useless-rename': 'error',
         'no-useless-return': 'error',
         'import/first': 'warn',


### PR DESCRIPTION
- Removes [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/) rule which is unnecessarily strict in my opinion
- Removes [`no-unreachable`](https://eslint.org/docs/latest/rules/no-unreachable) because the rule is part of `@typescript-eslint/recommended` by now
- Removes [`capitalized-comments`](https://eslint.org/docs/latest/rules/capitalized-comments) so auto-formatting does not mess up commented out code 
- Adds [`@typescript-eslint/switch-exhaustiveness-check`](https://typescript-eslint.io/rules/switch-exhaustiveness-check/) as we often work with switch statements over literal types and generally want them to be exhaustive